### PR TITLE
Bug 1712034: Disable support operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/support-operator/bin/support-operator /usr/bin/
 COPY config/pod.yaml /etc/support-operator/server.yaml
 COPY manifests /manifests
-LABEL io.openshift.release.operator=true
+#LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/usr/bin/support-operator"]


### PR DESCRIPTION
Needs to pass upgrade test to merge, there appears to be something wrong with how the pod is created that causes a termination loop.