### PR TITLE
status: Clear the initialized state more quickly

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -136,6 +136,9 @@ func (s *Support) Run(controller *controllercmd.ControllerContext) error {
 	var insightsClient *insightsclient.Client
 	if len(s.Endpoint) > 0 {
 		authorizer := clusterauthorizer.New(client)
+		if err := authorizer.Refresh(); err != nil {
+			klog.Warningf("Unable to retrieve initial config: %v", err)
+		}
 		insightsClient = insightsclient.New(nil, s.Endpoint, 0, "default", authorizer, configPeriodic)
 		go authorizer.Run(ctx, s.Interval)
 	}
@@ -144,6 +147,7 @@ func (s *Support) Run(controller *controllercmd.ControllerContext) error {
 	// is permanently disabled, but if a client does exist the server may still disable reporting
 	uploader := insightsuploader.New(recorder, insightsClient, statusReporter, s.Interval*6)
 	statusReporter.AddSources(uploader)
+	uploader.Init()
 
 	// TODO: future ideas
 	//

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -37,7 +37,7 @@ type Client struct {
 
 type Authorizer interface {
 	Authorize(req *http.Request) error
-	Enabled() (bool, string)
+	Enabled() (bool, time.Duration, string)
 }
 
 type ClusterVersionInfo interface {
@@ -54,8 +54,8 @@ var ErrWaitingForVersion = fmt.Errorf("waiting for the cluster version to be loa
 
 type nopAuthorizer struct{}
 
-func (nopAuthorizer) Authorize(_ *http.Request) error { return nil }
-func (nopAuthorizer) Enabled() (bool, string)         { return true, "" }
+func (nopAuthorizer) Authorize(_ *http.Request) error        { return nil }
+func (nopAuthorizer) Enabled() (bool, time.Duration, string) { return true, 0, "" }
 
 func New(client *http.Client, defaultEndpoint string, maxBytes int64, metricsName string, authorizer Authorizer, clusterInfo ClusterVersionInfo) *Client {
 	if client == nil {
@@ -79,7 +79,7 @@ func New(client *http.Client, defaultEndpoint string, maxBytes int64, metricsNam
 
 func (c *Client) Endpoint() string { return c.endpoint }
 
-func (c *Client) Enabled() (bool, string) {
+func (c *Client) Enabled() (bool, time.Duration, string) {
 	return c.authorizer.Enabled()
 }
 


### PR DESCRIPTION
When the interval is long, it may be several minutes before the
operator reports progressing false. Make that happen more quickly
by checking the client enabled status up front.

Also allow the upload interval to be configured in the secret -
this will eventually be replaced by real config, but we want CI
to report every 10 minutes so we are guaranteed to get some
output.