### PR TITLE
Check authorization/enablement more often

### DIFF
--- a/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
+++ b/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
@@ -96,7 +96,7 @@ func (a *Authorizer) Run(ctx context.Context, baseInterval time.Duration) {
 				klog.Errorf("Unable to refresh authorization secret: %v", err)
 				interval = baseInterval / 2
 			} else {
-				interval = baseInterval * 5
+				interval = baseInterval
 			}
 			time.Sleep(interval)
 		}

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/version"
 
@@ -140,7 +141,9 @@ func (s *Support) Run(controller *controllercmd.ControllerContext) error {
 			klog.Warningf("Unable to retrieve initial config: %v", err)
 		}
 		insightsClient = insightsclient.New(nil, s.Endpoint, 0, "default", authorizer, configPeriodic)
-		go authorizer.Run(ctx, s.Interval)
+		// TODO: convert the authorizer refresh to a watch on the support config object once that
+		// lands
+		go authorizer.Run(ctx, wait.Jitter(2*time.Minute, 0.5))
 	}
 
 	// upload results to the provided client - if no client is configured reporting


### PR DESCRIPTION
When the Support object lands this will be a watch, but for now we
want to be more responsive to enablement and disablement of the
operator while we CI test. 2-3m refresh is chosen to minimize API
load.