### PR TITLE
Reporting should react to config changes more rapidly (workaround until config object lands)

### DIFF
--- a/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
+++ b/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
@@ -178,6 +178,15 @@ func (a *Authorizer) Refresh() error {
 
 	a.lock.Lock()
 	defer a.lock.Unlock()
+
+	// log config transitions
+	if a.result.enabled != result.enabled {
+		if result.enabled {
+			klog.V(2).Infof("Operator is now enabled at interval=%s against endpoint=%s", result.interval, result.endpoint)
+		} else {
+			klog.V(2).Infof("Operator is now disabled")
+		}
+	}
 	a.result = result
 
 	return err


### PR DESCRIPTION
With the default hour interval it takes 1h for the uploader to refresh its state, instead we should watch for config boundaries and trigger an upload when they change.