### PR TITLE
Refactor configuration loading to be easier to reason about

### DIFF
--- a/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
+++ b/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
@@ -1,201 +1,38 @@
 package clusterauthorizer
 
 import (
-	"context"
 	"fmt"
 	"net/http"
-	"net/url"
-	"sync"
-	"time"
 
-	"k8s.io/klog"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/openshift/support-operator/pkg/authorizer"
+	"github.com/openshift/support-operator/pkg/config"
 )
 
-type authorizerResult struct {
-	enabled bool
-	message string
-	at      time.Time
-
-	endpoint string
-	token    string
-	username string
-	password string
-	interval time.Duration
+type Configurator interface {
+	Config() *config.Controller
 }
 
 type Authorizer struct {
-	client kubernetes.Interface
-
-	lock   sync.Mutex
-	result authorizerResult
+	configurator Configurator
 }
 
-func New(client kubernetes.Interface) *Authorizer {
+func New(configurator Configurator) *Authorizer {
 	return &Authorizer{
-		client: client,
+		configurator: configurator,
 	}
 }
 
 func (a *Authorizer) Authorize(req *http.Request) error {
-	result := a.latestResult()
-	if !result.enabled {
-		return authorizer.Error{Err: fmt.Errorf("no authorization info is currently available")}
-	}
-	if len(result.endpoint) > 0 {
-		endpoint, err := url.Parse(result.endpoint)
-		if err != nil {
-			return fmt.Errorf("configured endpoint is not a valid URL: %v", err)
-		}
-		req.Host = endpoint.Host
-		req.URL = endpoint
-	}
-	if len(result.username) > 0 || len(result.password) > 0 {
-		req.SetBasicAuth(result.username, result.password)
+	cfg := a.configurator.Config()
+	if len(cfg.Username) > 0 || len(cfg.Password) > 0 {
+		req.SetBasicAuth(cfg.Username, cfg.Password)
 		return nil
 	}
-	if len(result.token) > 0 {
+	if len(cfg.Token) > 0 {
 		if req.Header == nil {
 			req.Header = make(http.Header)
 		}
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", result.token))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cfg.Token))
 		return nil
 	}
 	return nil
-}
-
-// TODO: return a configuration struct, not boolean and string
-func (a *Authorizer) Enabled() (bool, time.Duration, string) {
-	result := a.latestResult()
-	if result.enabled {
-		return true, result.interval, ""
-	}
-	if len(result.message) == 0 {
-		return false, result.interval, "Reports will not be uploaded, no credentials specified."
-	}
-	return false, result.interval, result.message
-}
-
-func (a *Authorizer) latestResult() authorizerResult {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-	return a.result
-}
-
-func (a *Authorizer) Run(ctx context.Context, baseInterval time.Duration) {
-	wait.Until(func() {
-		for {
-			var interval time.Duration
-			if err := a.Refresh(); err != nil {
-				klog.Errorf("Unable to refresh authorization secret: %v", err)
-				interval = baseInterval / 2
-			} else {
-				interval = baseInterval
-			}
-			time.Sleep(interval)
-		}
-	}, 1*time.Minute, ctx.Done())
-}
-
-func (a *Authorizer) Refresh() error {
-	var err error
-	var result authorizerResult
-
-	secret, err := a.client.CoreV1().Secrets("openshift-config").Get("support", metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			klog.V(4).Infof("Support secret does not exist, reporting is disabled")
-			result.message = "Reporting is disabled until the openshift-config/support secret is created with username and password fields"
-			err = nil
-		} else if errors.IsForbidden(err) {
-			klog.V(2).Infof("Operator does not have permission to check support secret: %v", err)
-			err = nil
-		} else {
-			err = fmt.Errorf("could not check support secret: %v", err)
-		}
-	} else {
-		if username, ok := secret.Data["username"]; ok {
-			result.username = string(username)
-		}
-		if password, ok := secret.Data["password"]; ok {
-			result.password = string(password)
-		}
-		if endpoint, ok := secret.Data["endpoint"]; ok {
-			result.endpoint = string(endpoint)
-			result.enabled = len(result.endpoint) > 0
-			if !result.enabled {
-				result.message = "Reporting has been disabled via configuration"
-			}
-		} else {
-			result.enabled = true
-		}
-
-		if intervalString, ok := secret.Data["interval"]; ok {
-			duration, err := time.ParseDuration(string(intervalString))
-			if err == nil && duration < time.Minute {
-				err = fmt.Errorf("too short")
-			}
-			if err == nil {
-				result.interval = duration
-			} else {
-				err = fmt.Errorf("support secret interval must be a duration (1h, 10m) greater than or equal to one minute: %v", err)
-				result.enabled = false
-			}
-		}
-	}
-
-	// TODO: when endpoint supports token
-	// secret, err = a.client.CoreV1().Secrets("kube-system").Get("coreos-pull-secret", metav1.GetOptions{})
-	// if err != nil {
-	// 	if !errors.IsNotFound(err) && !errors.IsForbidden(err) {
-	// 		err = fmt.Errorf("could not check cloud token: %v", err)
-	// 	} else {
-	// 		klog.V(4).Infof("Unable to check system pull secret: %v", err)
-	// 	}
-	// } else {
-	// 	if data := secret.Data[".dockerconfigjson"]; len(data) > 0 {
-	// 		var pullSecret serializedAuthMap
-	// 		if err := json.Unmarshal(data, &pullSecret); err != nil {
-	// 			klog.Errorf("Unable to unmarshal system pull secret: %v", err)
-	// 		}
-	// 		if auth, ok := pullSecret.Auths["cloud.openshift.com"]; ok && len(auth.Auth) > 0 {
-	// 			klog.V(4).Info("Found cloud.openshift.com token")
-	// 			result.token = auth.Auth
-	// 			result.enabled = true
-	// 		}
-	// 	}
-	// }
-
-	if result.enabled {
-		result.at = time.Now()
-	}
-
-	a.lock.Lock()
-	defer a.lock.Unlock()
-
-	// log config transitions
-	if a.result.enabled != result.enabled {
-		if result.enabled {
-			klog.V(2).Infof("Operator is now enabled at interval=%s against endpoint=%s", result.interval, result.endpoint)
-		} else {
-			klog.V(2).Infof("Operator is now disabled")
-		}
-	}
-	a.result = result
-
-	return err
-}
-
-type serializedAuthMap struct {
-	Auths map[string]serializedAuth `json:"auths"`
-}
-
-type serializedAuth struct {
-	Auth string `json:"auth"`
 }

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -13,13 +13,16 @@ import (
 	"k8s.io/klog"
 
 	"github.com/openshift/support-operator/pkg/controller"
+	"github.com/openshift/support-operator/pkg/config"
 )
 
 func NewOperator() *cobra.Command {
 	operator := &controller.Support{
+		Controller: config.Controller {
 		StoragePath: "/var/lib/support-operator",
 		Interval:    10 * time.Minute,
 		Endpoint:    "https://cloud.redhat.com/api/ingress/v1/upload",
+		},
 	}
 	cfg := controllercmd.NewControllerCommandConfig("openshift-support-operator", version.Get(), operator.Run)
 	cmd := &cobra.Command{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+// Controller defines the standard config for this operator.
+type Serialized struct {
+	Report      bool   `json:"report"`
+	StoragePath string `json:"storagePath"`
+	Interval    string `json:"interval"`
+	Endpoint    string `json:"endpoint"`
+	Impersonate string `json:"impersonate"`
+}
+
+func (s *Serialized) ToController() (*Controller, error) {
+	cfg := Controller{
+		Report:      s.Report,
+		StoragePath: s.StoragePath,
+		Endpoint:    s.Endpoint,
+		Impersonate: s.Impersonate,
+	}
+	if len(s.Interval) > 0 {
+		d, err := time.ParseDuration(s.Interval)
+		if err != nil {
+			return nil, fmt.Errorf("interval must be a valid duration: %v", err)
+		}
+		cfg.Interval = d
+	}
+
+	if cfg.Interval <= 0 {
+		return nil, fmt.Errorf("interval must be a non-negative duration")
+	}
+	if len(cfg.StoragePath) == 0 {
+		return nil, fmt.Errorf("storagePath must point to a directory where snapshots can be stored")
+	}
+	return &cfg, nil
+}
+
+// Controller defines the standard config for this operator.
+type Controller struct {
+	Report      bool
+	StoragePath string
+	Interval    time.Duration
+	Endpoint    string
+	Impersonate string
+
+	Username string
+	Password string
+	Token    string
+}

--- a/pkg/config/configobserver/configobserver.go
+++ b/pkg/config/configobserver/configobserver.go
@@ -1,0 +1,230 @@
+package configobserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"github.com/openshift/support-operator/pkg/config"
+)
+
+type ConfigReporter interface {
+	SetConfig(*config.Controller)
+}
+
+type Controller struct {
+	kubeClient kubernetes.Interface
+
+	lock          sync.Mutex
+	defaultConfig config.Controller
+	tokenConfig   *config.Controller
+	secretConfig  *config.Controller
+	config        *config.Controller
+	listeners     []chan struct{}
+}
+
+func New(defaultConfig config.Controller, kubeClient kubernetes.Interface) *Controller {
+	c := &Controller{
+		kubeClient:    kubeClient,
+		defaultConfig: defaultConfig,
+	}
+	c.setConfigLocked(&defaultConfig)
+	if err := c.retrieveToken(); err != nil {
+		klog.Warningf("Unable to retrieve initial token config: %v", err)
+	}
+	if err := c.retrieveConfig(); err != nil {
+		klog.Warningf("Unable to retrieve initial config: %v", err)
+	}
+	return c
+}
+
+func (c *Controller) Start(ctx context.Context) {
+	// TODO: remove once pull-secret code is merged and replace with annotations on the support object
+	wait.Until(func() {
+		if err := c.retrieveConfig(); err != nil {
+			klog.Warningf("Unable to retrieve config: %v", err)
+		}
+	}, 5*time.Minute, ctx.Done())
+}
+
+func (c *Controller) retrieveToken() error {
+	var nextConfig config.Controller
+
+	klog.V(2).Infof("Refreshing configuration from cluster pull secret")
+	secret, err := c.kubeClient.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.V(4).Infof("pull-secret does not exist")
+			err = nil
+		} else if errors.IsForbidden(err) {
+			klog.V(2).Infof("Operator does not have permission to check pull-secret: %v", err)
+			err = nil
+		} else {
+			err = fmt.Errorf("could not check pull-secret: %v", err)
+		}
+	}
+	if secret != nil {
+		if data := secret.Data[".dockerconfigjson"]; len(data) > 0 {
+			var pullSecret serializedAuthMap
+			if err := json.Unmarshal(data, &pullSecret); err != nil {
+				klog.Errorf("Unable to unmarshal cluster pull-secret: %v", err)
+			}
+			if auth, ok := pullSecret.Auths["cloud.openshift.com"]; ok && len(auth.Auth) > 0 {
+				klog.V(4).Info("Found cloud.openshift.com token")
+				nextConfig.Token = auth.Auth
+			}
+		}
+		nextConfig.Report = true
+	}
+	if err != nil {
+		return err
+	}
+	c.setTokenConfig(&nextConfig)
+	return nil
+}
+
+func (c *Controller) retrieveConfig() error {
+	var nextConfig config.Controller
+
+	klog.V(2).Infof("Refreshing configuration from cluster secret")
+	secret, err := c.kubeClient.CoreV1().Secrets("openshift-config").Get("support", metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.V(4).Infof("Support secret does not exist")
+			err = nil
+		} else if errors.IsForbidden(err) {
+			klog.V(2).Infof("Operator does not have permission to check support secret: %v", err)
+			err = nil
+		} else {
+			err = fmt.Errorf("could not check support secret: %v", err)
+		}
+	}
+	if secret != nil {
+		if username, ok := secret.Data["username"]; ok {
+			nextConfig.Username = string(username)
+		}
+		if password, ok := secret.Data["password"]; ok {
+			nextConfig.Password = string(password)
+		}
+		if endpoint, ok := secret.Data["endpoint"]; ok {
+			nextConfig.Endpoint = string(endpoint)
+		}
+		nextConfig.Report = len(nextConfig.Endpoint) > 0
+
+		if intervalString, ok := secret.Data["interval"]; ok {
+			duration, err := time.ParseDuration(string(intervalString))
+			if err == nil && duration < time.Minute {
+				err = fmt.Errorf("too short")
+			}
+			if err == nil {
+				nextConfig.Interval = duration
+			} else {
+				err = fmt.Errorf("support secret interval must be a duration (1h, 10m) greater than or equal to one minute: %v", err)
+				nextConfig.Report = false
+			}
+		}
+	}
+	if err != nil {
+		return err
+	}
+	c.setSecretConfig(&nextConfig)
+	return nil
+}
+
+func (c *Controller) Config() *config.Controller {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.config
+}
+
+func (c *Controller) ConfigChanged() (<-chan struct{}, func()) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	position := -1
+	for i := range c.listeners {
+		if c.listeners == nil {
+			position = i
+			break
+		}
+	}
+	if position == -1 {
+		c.listeners = append(c.listeners, nil)
+		position = len(c.listeners) - 1
+	}
+	ch := make(chan struct{}, 1)
+	c.listeners[position] = ch
+	return ch, func() {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+		c.listeners[position] = nil
+	}
+}
+
+func (c *Controller) setTokenConfig(config *config.Controller) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.tokenConfig = config
+	c.mergeConfigLocked()
+}
+
+func (c *Controller) setSecretConfig(config *config.Controller) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.secretConfig = config
+	c.mergeConfigLocked()
+}
+
+func (c *Controller) mergeConfigLocked() {
+	cfg := c.defaultConfig
+	if c.secretConfig != nil {
+		cfg.Username = c.secretConfig.Username
+		cfg.Password = c.secretConfig.Password
+		if c.secretConfig.Interval > 0 {
+			cfg.Interval = c.secretConfig.Interval
+		}
+		if len(c.secretConfig.Endpoint) > 0 {
+			cfg.Endpoint = c.secretConfig.Endpoint
+		}
+	}
+	if c.tokenConfig != nil {
+		cfg.Token = c.tokenConfig.Token
+	}
+	cfg.Report = len(cfg.Endpoint) > 0 && (len(cfg.Token) > 0 || len(cfg.Username) > 0)
+	c.setConfigLocked(&cfg)
+}
+
+func (c *Controller) setConfigLocked(config *config.Controller) {
+	if c.config != nil {
+		if !reflect.DeepEqual(c.config, config) {
+			klog.V(2).Infof("Configuration updated: enabled=%t endpoint=%s interval=%s username=%t token=%t", config.Report, config.Endpoint, config.Interval, len(config.Username) > 0, len(config.Token) > 0)
+			for _, ch := range c.listeners {
+				if ch == nil {
+					continue
+				}
+				select {
+				case ch <- struct{}{}:
+				default:
+				}
+			}
+		}
+	} else {
+		klog.V(2).Infof("Configuration set: enabled=%t endpoint=%s interval=%s username=%t token=%t", config.Report, config.Endpoint, config.Interval, len(config.Username) > 0, len(config.Token) > 0)
+	}
+	c.config = config
+}
+
+type serializedAuthMap struct {
+	Auths map[string]serializedAuth `json:"auths"`
+}
+type serializedAuth struct {
+	Auth string `json:"auth"`
+}

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -148,7 +148,12 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 	}
 	var disabledMessage string
 	if !c.configurator.Config().Report {
-		disabledMessage = fmt.Sprintf("Health reporting is disabled")
+		disabledMessage = "Health reporting is disabled"
+	}
+	// NotAuthorized is a special case where we want to disable the operator
+	if reason == "NotAuthorized" {
+		disabledMessage = errorMessage
+		errorMessage = ""
 	}
 
 	existing = existing.DeepCopy()

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -13,15 +13,14 @@ import (
 
 	"golang.org/x/time/rate"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"k8s.io/klog"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/support-operator/pkg/config"
 	"github.com/openshift/support-operator/pkg/controllerstatus"
 )
 
@@ -29,10 +28,15 @@ type Reported struct {
 	LastReportTime metav1.Time `json:"lastReportTime"`
 }
 
+type Configurator interface {
+	Config() *config.Controller
+}
+
 type Controller struct {
-	name     string
-	client   configv1client.ConfigV1Interface
-	statusCh chan struct{}
+	name         string
+	client       configv1client.ConfigV1Interface
+	statusCh     chan struct{}
+	configurator Configurator
 
 	lock     sync.Mutex
 	sources  []controllerstatus.Interface
@@ -40,12 +44,14 @@ type Controller struct {
 	start    time.Time
 }
 
-func NewController(client configv1client.ConfigV1Interface) *Controller {
-	return &Controller{
-		name:     "support",
-		client:   client,
-		statusCh: make(chan struct{}, 1),
+func NewController(client configv1client.ConfigV1Interface, configurator Configurator) *Controller {
+	c := &Controller{
+		name:         "support",
+		client:       client,
+		statusCh:     make(chan struct{}, 1),
+		configurator: configurator,
 	}
+	return c
 }
 
 func (c *Controller) triggerStatusUpdate() {
@@ -106,7 +112,6 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 	var last time.Time
 	var reason string
 	var errors []string
-	var disabled []string
 	allReady := true
 	for i, source := range c.Sources() {
 		summary, ready := source.CurrentStatus()
@@ -123,13 +128,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			continue
 		}
 		reason = summary.Reason
-		if summary.Disabled {
-			klog.V(4).Infof("Source %d %T reports disabled", i, source)
-			disabled = append(disabled, summary.Message)
-		} else {
-			klog.V(4).Infof("Source %d %T reports error", i, source)
-			errors = append(errors, summary.Message)
-		}
+		errors = append(errors, summary.Message)
 		if last.Before(summary.LastTransitionTime) {
 			last = summary.LastTransitionTime
 		}
@@ -148,9 +147,8 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 		errorMessage = fmt.Sprintf("There are multiple errors blocking progress:\n* %s", strings.Join(errors, "\n* "))
 	}
 	var disabledMessage string
-	if len(disabled) > 0 {
-		sort.Strings(disabled)
-		disabledMessage = disabled[0]
+	if !c.configurator.Config().Report {
+		disabledMessage = fmt.Sprintf("Health reporting is disabled")
 	}
 
 	existing = existing.DeepCopy()
@@ -231,7 +229,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 		}
 
 	case len(errorMessage) > 0:
-		klog.V(4).Infof("The operator has some internal errors")
+		klog.V(4).Infof("The operator has some internal errors: %s", errorMessage)
 		setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 			Type:    configv1.OperatorProgressing,
 			Status:  configv1.ConditionFalse,

--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -12,7 +12,6 @@ type Interface interface {
 }
 
 type Summary struct {
-	Disabled           bool
 	Healthy            bool
 	Reason             string
 	Message            string
@@ -31,8 +30,8 @@ func (s *Simple) UpdateStatus(summary Summary) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if s.summary.Healthy != summary.Healthy || s.summary.Disabled != summary.Disabled {
-		klog.V(2).Infof("name=%s healthy=%t disabled=%t reason=%s message=%s", s.Name, summary.Healthy, summary.Disabled, summary.Reason, summary.Message)
+	if s.summary.Healthy != summary.Healthy {
+		klog.V(2).Infof("name=%s healthy=%t reason=%s message=%s", s.Name, summary.Healthy, summary.Reason, summary.Message)
 		if summary.LastTransitionTime.IsZero() {
 			summary.LastTransitionTime = time.Now()
 		}
@@ -47,7 +46,7 @@ func (s *Simple) UpdateStatus(summary Summary) {
 		return
 	}
 	if s.summary.Message != summary.Message || s.summary.Reason != summary.Reason {
-		klog.V(2).Infof("name=%s healthy=%t disabled=%t reason=%s message=%s", s.Name, summary.Healthy, summary.Disabled, summary.Reason, summary.Message)
+		klog.V(2).Infof("name=%s healthy=%t reason=%s message=%s", s.Name, summary.Healthy, summary.Reason, summary.Message)
 		s.summary.Reason = summary.Reason
 		s.summary.Message = summary.Message
 		return


### PR DESCRIPTION
Refactor how the pull secret and cluster config secrets are loaded into something easier to maintain.  Builds off work in #15, has no risk to config.  Matches our decision to make this an up front choice at pull secret creation time.

Handles NotAuthorized from upstream as "Disabled=true" instead of "Degraded=true" so we can switch over without causing clusters to be degraded.