### PR TITLE
manifests: Grant access to the cluster pull-secret to get token

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -143,6 +143,7 @@ rules:
   resources:
   - secrets
   resourceNames:
+  - pull-secret
   - support
   verbs:
   - get


### PR DESCRIPTION
Cloud token is used to report support information.

Covers the last part of #15 not captured in #17